### PR TITLE
Directly loading of the JavaScript file was replaced by the {load_script} tag.

### DIFF
--- a/RegistrationNotificationPlugin.inc.php
+++ b/RegistrationNotificationPlugin.inc.php
@@ -179,11 +179,4 @@ class RegistrationNotificationPlugin extends GenericPlugin {
 	public function getInstallSitePluginSettingsFile() {
 		return $this->getPluginPath() . '/settings.xml';
 	}
-
-	/**
-	 * Get the JavaScript URL for this plugin.
-	 */
-	public function getJavaScriptURL($request) {
-		return $request->getBaseUrl() . '/' . $this->getPluginPath() . '/js';
-	}	
 }

--- a/RegistrationNotificationSettingsForm.inc.php
+++ b/RegistrationNotificationSettingsForm.inc.php
@@ -74,10 +74,16 @@ class RegistrationNotificationSettingsForm extends Form {
 	 * @copydoc Form::fetch()
 	 */
 	public function fetch($request) {
-		TemplateManager::getManager($request)->assign([
-			'pluginName' => $this->_plugin->getName(),
-			'pluginJavaScriptURL' => $this->_plugin->getJavaScriptURL($request)
-		]);
+		$templateManager = TemplateManager::getManager($request);
+		$templateManager->assign('pluginName', $this->_plugin->getName());
+		$templateManager->addJavaScript(
+			'RegistrationNotificationFormHandler',
+			$request->getBaseUrl() . '/' . $this->_plugin->getPluginPath() . '/js/RegistrationNotificationFormHandler.js',
+			[
+				'priority' => STYLE_SEQUENCE_CORE,
+				'contexts' => 'RegistrationNotificationSettingsForm'
+			]
+		);
 		return parent::fetch($request);
 	}
 

--- a/templates/settingsForm.tpl
+++ b/templates/settingsForm.tpl
@@ -8,7 +8,7 @@
  * Registration Notification plugin settings
  *
  *}
-<script src="{$pluginJavaScriptURL}/RegistrationNotificationFormHandler.js"></script>
+{load_script context="RegistrationNotificationSettingsForm"}
 <script>
 	$(function() {ldelim}
 		// Attach the form handler.


### PR DESCRIPTION
Hi @asmecher, I was busy moving to another flat, but here goes the fix.
If everything is ok, I might apply it to the other places where I found the same approach.